### PR TITLE
fix: resolve the inconsistent animation speed issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,9 @@ import Animated, {
   runOnJS,
   useAnimatedReaction,
   useAnimatedStyle,
-  useFrameCallback,
   useSharedValue,
 } from 'react-native-reanimated';
+import { useEffect } from 'react';
 
 const AnimatedChild = ({
   index,
@@ -53,9 +53,20 @@ export const Marquee = React.memo(
     const [cloneTimes, setCloneTimes] = React.useState(0);
     const anim = useSharedValue(0);
 
-    useFrameCallback(() => {
-      anim.value += speed;
-    }, true);
+    useEffect(() => {
+      let frameCallbackId;
+
+      const frameCallback = () => {
+        anim.value += speed;
+        frameCallbackId = requestAnimationFrame(frameCallback);
+      };
+      frameCallback();
+      return () => {
+        if (frameCallbackId) {
+          cancelAnimationFrame(frameCallbackId);
+        }
+      };
+    }, [anim, speed]);
 
     useAnimatedReaction(
       () => {


### PR DESCRIPTION
In the screen where I used the marquee animation, the animation speed was inconsistent (either too slow or too fast) when navigation movements occurred or when the app state changed. To address this, I replaced the useFrameCallback with useEffect and requestAnimationFrame to adjust the animation speed, and this worked successfully for me.