### PR TITLE
feat: add frameRate prop

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <StatusBar hidden />
-      <Marquee spacing={20} speed={1}>
+      <Marquee spacing={20} speed={1} frameRate={60}>
         <Heading primary={primary}>
           @animatereactnative/marquee component
         </Heading>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ const AnimatedChild = ({
 
 export type MarqueeProps = React.PropsWithChildren<{
   speed?: number;
+  frameRate?: number;
   spacing?: number;
   style?: ViewStyle;
 }>;
@@ -47,14 +48,22 @@ export type MarqueeProps = React.PropsWithChildren<{
  * Used to animate the given children in a horizontal manner.
  */
 export const Marquee = React.memo(
-  ({ speed = 1, children, spacing = 0, style }: MarqueeProps) => {
+  ({ speed = 1, children, spacing = 0, style, frameRate }: MarqueeProps) => {
     const parentWidth = useSharedValue(0);
     const textWidth = useSharedValue(0);
     const [cloneTimes, setCloneTimes] = React.useState(0);
     const anim = useSharedValue(0);
 
-    useFrameCallback(() => {
-      anim.value += speed;
+    const frameRateMs = frameRate ? 1000 / frameRate : null;
+
+    useFrameCallback((frameInfo) => {
+      if (frameInfo.timeSincePreviousFrame === null) return;
+
+      const frameDelta = frameRateMs
+        ? frameInfo.timeSincePreviousFrame / frameRateMs
+        : 1;
+
+      anim.value += speed * frameDelta;
     }, true);
 
     useAnimatedReaction(


### PR DESCRIPTION
First of all, thank you for the great work!

In this PR, I added a frameRate prop to ensure consistent marquee speed across devices when needed.

At times, even with the same speed value, marquee speed appeared inconsistently across devices due to differing frame rates. 

I’ve added a frameRate prop to align marquee speed with a specific frame rate.

### Usage
```jsx
  // Set frameRate to 60fps
  <Marquee spacing={20} speed={1} frameRate={60}>
    <Heading primary={primary}>
      @animatereactnative/marquee component
    </Heading>
  </Marquee>

  // Set frameRate to 30fps
  <Marquee spacing={20} speed={1} frameRate={30}>
    <Heading primary={primary}>
      @animatereactnative/marquee component
    </Heading>
  </Marquee>
```

Thanks for reviewing, and let me know if there are any questions or further improvements needed!